### PR TITLE
Dynamically detect latest version of shinyserver

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,3 +8,5 @@ Maintainer: Andrea Cirillo <andreacirilloac@gmail.com>
 Description: the main aim of ramazon is to relieve the pain of publish shiny apps on Amazon EC2 instances.This is obtained providing a single function, ramazon(), able to take care of everything needed in order to install R, shiny-server and the user shiny app on a Ubuntu 14.0 server running on the Amazon EC2 instance.
 License: MIT
 LazyData: TRUE
+Imports:
+    XML

--- a/R/ramazon_mac.R
+++ b/R/ramazon_mac.R
@@ -69,10 +69,12 @@ sink()
 #XML is needed for this next chunk:
 #Here we parse the xml of download3.rstudio.org/
 #Using the rootsize we can extract the last entry which is the latest version of shiny server
-if(!require(XML)){
-  install.packages("XML")
-  library(XML)
-}
+
+#added 'Import' to DESCRIPTION for XML
+#if(!require(XML)){
+#  install.packages("XML")
+#  library(XML)
+#}
 xml.url <- 'http://download3.rstudio.org/'
 xmlParsed <- xmlParse(xml.url)
 rootnode <- xmlRoot(xmlParsed)

--- a/R/ramazon_mac.R
+++ b/R/ramazon_mac.R
@@ -66,11 +66,23 @@ sink("bash_script.txt", append = TRUE)
 message <-  cat("sudo su -\\-c \"R -e \\\"install.packages(",packages,", repos = 'http://cran.rstudio.com/', dep = TRUE)\\\"\"")
 sink()
 
+if(!require(XML)){
+  install.packages("XML")
+  library(XML)
+}
+
+xml.url <- 'http://download3.rstudio.org/'
+result <- xmlParse(xml.url)
+rootnode <- xmlRoot(result)
+rootsize <- xmlSize(rootnode)
+latest_shiny_path <- xmlValue(rootnode[[rootsize]][[1]])
+shiny_version <- unlist(strsplit(latest_shiny_path,'/'))[3]
+  
 # install latest Shiny server version
 command <- c("\necho 'R installed'")
 command <- append(command,"sudo apt-get install -y gdebi-core")
-command <- append(command,"wget https://download3.rstudio.org/ubuntu-12.04/x86_64/shiny-server-1.5.3.838-amd64.deb")
-command <- append(command,"sudo gdebi --non-interactive shiny-server-1.5.3.838-amd64.deb")
+command <- append(command,paste0("wget https://download3.rstudio.org/",latest_shiny_path))
+command <- append(command,paste0("sudo gdebi --non-interactive ",shiny_version))
 
 # add deleting permission
 command <- append(command,"")

--- a/R/ramazon_mac.R
+++ b/R/ramazon_mac.R
@@ -66,14 +66,16 @@ sink("bash_script.txt", append = TRUE)
 message <-  cat("sudo su -\\-c \"R -e \\\"install.packages(",packages,", repos = 'http://cran.rstudio.com/', dep = TRUE)\\\"\"")
 sink()
 
+#XML is needed for this next chunk:
+#Here we parse the xml of download3.rstudio.org/
+#Using the rootsize we can extract the last entry which is the latest version of shiny server
 if(!require(XML)){
   install.packages("XML")
   library(XML)
 }
-
 xml.url <- 'http://download3.rstudio.org/'
-result <- xmlParse(xml.url)
-rootnode <- xmlRoot(result)
+xmlParsed <- xmlParse(xml.url)
+rootnode <- xmlRoot(xmlParsed)
 rootsize <- xmlSize(rootnode)
 latest_shiny_path <- xmlValue(rootnode[[rootsize]][[1]])
 shiny_version <- unlist(strsplit(latest_shiny_path,'/'))[3]

--- a/R/ramazon_mac.R
+++ b/R/ramazon_mac.R
@@ -76,10 +76,10 @@ sink()
 #  library(XML)
 #}
 xml.url <- 'http://download3.rstudio.org/'
-xmlParsed <- xmlParse(xml.url)
-rootnode <- xmlRoot(xmlParsed)
-rootsize <- xmlSize(rootnode)
-latest_shiny_path <- xmlValue(rootnode[[rootsize]][[1]])
+xmlParsed <- XML::xmlParse(xml.url)
+rootnode <- XML::xmlRoot(xmlParsed)
+rootsize <- XML::xmlSize(rootnode)
+latest_shiny_path <- XML::xmlValue(rootnode[[rootsize]][[1]])
 shiny_version <- unlist(strsplit(latest_shiny_path,'/'))[3]
   
 # install latest Shiny server version


### PR DESCRIPTION
This update adds an XML parse of the 'http://download3.rstudio.org/' download page. It uses the call `xmlSize(rootnode)` to find the end of the xml which contains the latest version of shinyserver for ubuntu. This parse will break if shinyserver changes the layout of their download page so let's hope they don't do that. The complete annotation of the code is as follows;
``` R
#first we specify the download page 
xml.url <- 'http://download3.rstudio.org/' 
#now we parse the xml 
xmlParsed <- XML::xmlParse(xml.url) 
#these two commands get the node and size respectively 
rootnode <- XML::xmlRoot(xmlParsed) 
rootsize <- XML::xmlSize(rootnode) 
#this subsets the rootnode by taking the last entry [rootize][1]. This now contains the path to the download. 
latest_shiny_path <- XML::xmlValue(rootnode[[rootsize]][[1]]) 
#then we use a simple string split by '/' to extract just the file name from the url.
shiny_version <- unlist(strsplit(latest_shiny_path,'/'))[3] 

#these are then added to the 'command' document 
command <- c("\necho 'R installed'")
command <- append(command,"sudo apt-get install -y gdebi-core")
command <- append(command,paste0("wget https://download3.rstudio.org/",latest_shiny_path))
command <- append(command,paste0("sudo gdebi --non-interactive ",shiny_version))
